### PR TITLE
COF #18041 - Revertendo ajustes

### DIFF
--- a/src/main/java/org/jrimum/bopepo/campolivre/CLBancoobCobrancaNaoRegistrada.java
+++ b/src/main/java/org/jrimum/bopepo/campolivre/CLBancoobCobrancaNaoRegistrada.java
@@ -157,9 +157,9 @@ public class CLBancoobCobrancaNaoRegistrada extends AbstractCLBancoob{
 	private static final Integer DV_NOSSO_NUMERO_LENGTH = Integer.valueOf(1);
 
 	/**
-	 * Tamanho do campo Conta = 07
+	 * Tamanho do campo Conta = 06
 	 */
-	private static final Integer CONTA_LENGTH = Integer.valueOf(7);
+	private static final Integer CONTA_LENGTH = Integer.valueOf(6);
 
 	/**
 	 * Tamanho do campo Dígito da conta = 1
@@ -202,7 +202,7 @@ public class CLBancoobCobrancaNaoRegistrada extends AbstractCLBancoob{
 		checkTamanhoDigitoDoNossoNumero(titulo, DV_NOSSO_NUMERO_LENGTH);
 		checkNumeroDaContaNotNull(titulo);
 		checkCodigoDoNumeroDaConta(titulo);
-		checkCodigoDoNumeroDaContaMenorOuIgualQue(titulo, 9999999);
+		checkCodigoDoNumeroDaContaMenorOuIgualQue(titulo, 999999);
 		checkDigitoDoCodigoDoNumeroDaConta(titulo);
 	}
 


### PR DESCRIPTION
Entendo o caso com o banco, descobri que o 'Código do associado/cliente' deve-se usar o Cliente-DV, assim ficou claro que o valor a ser utilizado deveria ser o 2193604, este que possui 6 dígitos + 1 verificador, mantendo assim os 6 caracteres para o número da conta, o que fez necessário voltar os tratamentos e manter apenas a validação de tamanho do número da conta para os 6 caracteres.
